### PR TITLE
Change gem reference to kendoui-rails in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ kendo-rails has not been tested against any other versions of these libraries. Y
 
 In your Gemfile, add this line:
 
-    gem 'kendo-rails'
+    gem 'kendoui-rails'
 
 Then, run `bundle install`. 
 


### PR DESCRIPTION
The gem kendo-rails didn't exist. Perhaps the name changed at some point? It
looks like the current gem on rubygems is kendoui-rails.
