### PR TITLE
Change gem reference kendo-rails to kendoui-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kendo-rails has not been tested against any other versions of these libraries. Y
 
 In your Gemfile, add this line:
 
-    gem 'kendo-rails'
+    gem 'kendoui-rails'
 
 Then, run `bundle install`. 
 


### PR DESCRIPTION
I have this messages when I try to run `bundle install`

``` bash
% bundle install
Fetching source index from https://rubygems.org/
Resolving dependencies...
Could not find gem 'kendo-rails (>= 0) ruby' in the gems available on this machine.
```

and I try to run `gem install kendo-rails`

``` bash
% gem install kendo-rails
ERROR:  Could not find a valid gem 'kendo-rails' (>= 0) in any repository
ERROR:  Possible alternatives: kendoui-rails, kanso-rails, koko_rails, pen-rails, neo-rails
```

The gem `kendo-rails` didn't exsist.
Perhaps it is typo of `gem 'kendoui-rails'` ?
